### PR TITLE
Update lnd and resolve eclair syncing

### DIFF
--- a/conf/bitcoind/bitcoin.conf
+++ b/conf/bitcoind/bitcoin.conf
@@ -8,6 +8,7 @@ rpcport=43782
 rpcbind=0.0.0.0:43782
 rpcallowip=0.0.0.0/0
 whitelist=0.0.0.0/0
+zmqpubhashblock=tcp://0.0.0.0:28332
 zmqpubrawblock=tcp://0.0.0.0:28332
 zmqpubrawtx=tcp://0.0.0.0:28333
 deprecatedrpc=signrawtransaction

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:1.21.4-bookworm AS builder
 
 # References for lnd
-ARG LNDE_REF=v0.18.0-beta.rc1
+ARG LNDE_REF=v0.18.0-beta.rc2
 
 # Set the working directory in the Docker image
 WORKDIR /usr/src

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -125,14 +125,6 @@ openChannel() {
   mineBlocks $BITCOIN_ADDRESS 10
 }
 
-forceEclairSync() {
-  eclair1 stop
-  sleep 30
-  mineBlocks $BITCOIN_ADDRESS 1
-  sleep 30
-  mineBlocks $BITCOIN_ADDRESS 1
-}
-
 waitForNodes() {
   waitFor bitcoind getnetworkinfo
   waitFor lnd1 getinfo
@@ -148,7 +140,6 @@ main() {
   initBitcoinChain
   fundNodes
   openChannel
-  forceEclairSync
 }
 
 main


### PR DESCRIPTION
This pull request includes changes to the Bitcoin configuration, Dockerfile, and initialization script. The most significant modifications are an added configuration to the Bitcoin daemon, an update to the Dockerfile's reference version, and the removal of a function and its call in the initialization script.

Configuration changes:
* [`conf/bitcoind/bitcoin.conf`](diffhunk://#diff-7b7f8f4d802456519f286fe8cd85a7916ea825fd1a1fdae0d855b13225593f3fR11): Added a new configuration `zmqpubhashblock=tcp://0.0.0.0:28332` to the Bitcoin daemon configuration file. This configuration enables publishing of hash block notifications to a ZeroMQ socket.

Dockerfile update:
* [`docker/lnd/Dockerfile`](diffhunk://#diff-192b12143d8276b1b924fa15b5ee7e0460ec642f7ea5c4cca893260f9be79967L7-R7): Updated the `LNDE_REF` argument from `v0.18.0-beta.rc1` to `v0.18.0-beta.rc2`. This change updates the version of the Lightning Network Daemon (lnd) that the Docker image will use.

Initialization script changes:
* [`scripts/init.sh`](diffhunk://#diff-e28b09372ab7f9778c87c348a91532b491c793208b25f9f0f7b46b7154db45ffL128-L135): Removed the `forceEclairSync` function and its call in the `main` function. This function was previously used to force Eclair to sync with the Bitcoin network. Its removal suggests that this force sync is no longer necessary or is being handled differently. [[1]](diffhunk://#diff-e28b09372ab7f9778c87c348a91532b491c793208b25f9f0f7b46b7154db45ffL128-L135) [[2]](diffhunk://#diff-e28b09372ab7f9778c87c348a91532b491c793208b25f9f0f7b46b7154db45ffL151)