### PR TITLE
Use multiarch cln image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,14 +38,14 @@ services:
         ipv4_address: 172.30.1.3
 
   cln1:
-    image: elementsproject/lightningd:v23.11.2-arm64v8
+    image: cyphernode/clightning:v23.11.2
     restart: unless-stopped
     depends_on:
       - bitcoind
     networks:
       testing_net:
         ipv4_address: 172.30.1.30
-    command: --network=regtest --addr=cln1:9735
+    command: lightningd --network=regtest --addr=cln1:9735
     volumes:
       - "cln1:/root/.lightning"
       - "./conf/cln/config:/root/.lightning/config"


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file, specifically within the `cln1` service configuration. The `image` field has been updated to use a different Docker image, and the `command` field has been modified to include the name of the executable.

Changes:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L41-R48): Updated the `image` field for the `cln1` service from `elementsproject/lightningd:v23.11.2-arm64v8` to `cyphernode/clightning:v23.11.2`. This change indicates a switch to a different Docker image for the `cln1` service.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L41-R48): Modified the `command` field for the `cln1` service to include the executable name `lightningd` before the command-line arguments. This change ensures that the correct executable is run when the Docker container starts.