### PR TITLE
Enable trace debugging for lndk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
     depends_on:
       - lnd1
-    command: --address=https://lnd1:10009 --cert=/root/.lnd/tls.cert --macaroon=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon
+    command: --address=https://lnd1:10009 --cert=/root/.lnd/tls.cert --macaroon=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace
     environment:
       - RUST_BACKTRACE=1
     volumes:


### PR DESCRIPTION
This pull request includes a minor but important change to the `docker-compose.yml` file. The `command` for a service has been updated to include a `--log-level=trace` flag, which will enhance the logging details for debugging and troubleshooting purposes. This change will provide more detailed logs and therefore improve the ability to diagnose and fix issues.