### PR TITLE
Set eclair public ip as ip address

### DIFF
--- a/conf/eclair/eclair.conf
+++ b/conf/eclair/eclair.conf
@@ -4,7 +4,7 @@ eclair {
 
   server {
     port=9735
-    public-ips = [ "eclair1" ]
+    public-ips = [ "172.30.1.31" ]
   }
 
   bitcoind {


### PR DESCRIPTION
This pull request includes a change to the `eclair.conf` file in the `conf/eclair` directory. The change updates the `public-ips` property under the `server` section from `"eclair1"` to `"172.30.1.31"`. This is likely a configuration change to reflect the current environment.