### PR TITLE
Fix CLN connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This command displays a list of all commands that you can issue against the `ecl
 
 ### Paying to an Eclair node that is two hops away
 
-**Generate a bolt 12 offeron eclair2:**
+**Generate a bolt 12 offer on eclair2:**
 
 ```sh
 ./bin/eclair-cli eclair2 tipjarshowoffer
@@ -111,7 +111,7 @@ This command displays a list of all commands that you can issue against the `ecl
 **Generate a bolt 12 offer:**
 
 ```sh
-./bin/lightning-cli cln1 offer 10000 "test offer from cln"
+./bin/lightning-cli cln1 offer 1000 "test offer from cln"
 ```
 
 **Pay to bolt 12 offer:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     networks:
       testing_net:
         ipv4_address: 172.30.1.30
-    command: --network=regtest --addr=cln1 --addr=0.0.0.0:9735
+    command: --network=regtest --addr=0.0.0.0:9735 --announce-addr=172.30.1.30:9735 --developer --dev-fast-gossip --dev-bitcoind-poll=2 --alias=cln1
     volumes:
       - "cln1:/root/.lightning"
       - "bitcoind:/root/.lightning/bitcoin"
@@ -75,7 +75,7 @@ services:
     networks:
       testing_net:
         ipv4_address: 172.30.2.1
-    command: --externalip=172.30.2.1 --externalip=lnd1:9735 --tlsextradomain=lnd1 --alias=lnd2
+    command: --externalip=172.30.2.1 --externalip=lnd2:9735 --tlsextradomain=lnd2 --alias=lnd2
     volumes:
       - "lnd2:/root/.lnd"
       - "./conf/lnd/lnd.conf:/root/.lnd/lnd.conf"
@@ -103,7 +103,7 @@ services:
     networks:
       testing_net:
         ipv4_address: 172.30.2.30
-    command: --network=regtest --addr=cln2 --addr=0.0.0.0:9735
+    command: --network=regtest --addr=0.0.0.0:9735 --announce-addr=172.30.2.30:9735 --developer --dev-fast-gossip --dev-bitcoind-poll=2 --alias=cln2
     volumes:
       - "cln2:/root/.lightning"
       - "bitcoind:/root/.lightning/bitcoin"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -87,8 +87,8 @@ getNodeInfo() {
 
   CLN1_NODE_INFO=$(cln1 getinfo)
   CLN1_PUBKEY=$(echo ${CLN1_NODE_INFO} | jq -r .id)
-  CLN1_IP_ADDRESS=$(echo ${CLN1_NODE_INFO} | jq -r '.binding[0].address')
-  CLN1_PORT=$(echo ${CLN1_NODE_INFO} | jq -r '.binding[0].port')
+  CLN1_IP_ADDRESS=$(echo ${CLN1_NODE_INFO} | jq -r '.address[0].address')
+  CLN1_PORT=$(echo ${CLN1_NODE_INFO} | jq -r '.address[0].port')
   CLN1_NODE_URI="${CLN1_PUBKEY}@${CLN1_IP_ADDRESS}:${CLN1_PORT}"
   echo CLN1_PUBKEY: $CLN1_PUBKEY
   echo CLN1_NODE_URI: $CLN1_NODE_URI
@@ -110,8 +110,8 @@ getNodeInfo() {
 
   CLN2_NODE_INFO=$(cln2 getinfo)
   CLN2_PUBKEY=$(echo ${CLN2_NODE_INFO} | jq -r .id)
-  CLN2_IP_ADDRESS=$(echo ${CLN2_NODE_INFO} | jq -r '.binding[0].address')
-  CLN2_PORT=$(echo ${CLN2_NODE_INFO} | jq -r '.binding[0].port')
+  CLN2_IP_ADDRESS=$(echo ${CLN2_NODE_INFO} | jq -r '.address[0].address')
+  CLN2_PORT=$(echo ${CLN2_NODE_INFO} | jq -r '.address[0].port')
   CLN2_NODE_URI="${CLN2_PUBKEY}@${CLN2_IP_ADDRESS}:${CLN2_PORT}"
   echo CLN2_PUBKEY: $CLN2_PUBKEY
   echo CLN2_NODE_URI: $CLN2_NODE_URI


### PR DESCRIPTION
This pull request includes changes to the `README.md`, `docker-compose.yml`, and `scripts/init.sh` files. The changes primarily involve adjustments to command parameters and address retrieval in the scripts. The most significant changes include modifying the bolt 12 offer command in the README, updating the command parameters in the `docker-compose.yml` file, and altering the method of retrieving IP addresses and ports in the `scripts/init.sh` file.

Command Adjustments:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R114): The bolt 12 offer command has been changed to offer 1000 instead of 10000.

Docker Compose Changes:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L49-R49): The command parameters for the services have been updated. For the `cln1` and `cln2` services, additional parameters like `--announce-addr`, `--developer`, `--dev-fast-gossip`, and `--dev-bitcoind-poll` have been added. Also, the `--addr` parameter has been modified. For the `lnd2` service, the `--externalip` and `--tlsextradomain` parameters have been updated. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L49-R49) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L78-R78) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L106-R106)

Script Changes:

* [`scripts/init.sh`](diffhunk://#diff-e28b09372ab7f9778c87c348a91532b491c793208b25f9f0f7b46b7154db45ffL90-R91): The method of retrieving the IP address and port for `CLN1` and `CLN2` has been changed from using `.binding[0].address` and `.binding[0].port` to `.address[0].address` and `.address[0].port`, respectively. [[1]](diffhunk://#diff-e28b09372ab7f9778c87c348a91532b491c793208b25f9f0f7b46b7154db45ffL90-R91) [[2]](diffhunk://#diff-e28b09372ab7f9778c87c348a91532b491c793208b25f9f0f7b46b7154db45ffL113-R114)