### PR TITLE
Wait for lnd and stagger startup time for lndk

### DIFF
--- a/conf/lnd/lnd.conf
+++ b/conf/lnd/lnd.conf
@@ -1,4 +1,5 @@
 rpclisten=0.0.0.0:10009
+restlisten=0.0.0.0:8080
 trickledelay=1000
 noseedbackup=true
 debuglevel=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,14 @@ services:
     restart: unless-stopped
     depends_on:
       - lnd1
+    entrypoint: ["/wait-for-lnd.sh", "lnd1", "1"]
     command: --address=https://lnd1:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
     environment:
       - RUST_BACKTRACE=1
     volumes:
       - "lndk1:/root/.lndk"
       - "lnd1:/root/.lnd:ro"
+      - "./docker/lndk/wait-for-lnd.sh:/wait-for-lnd.sh"
     networks:
       testing_net:
         ipv4_address: 172.30.1.3
@@ -87,12 +89,14 @@ services:
     restart: unless-stopped
     depends_on:
       - lnd2
+    entrypoint: ["/wait-for-lnd.sh", "lnd2", "3"]
     command: --address=https://lnd2:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
     environment:
       - RUST_BACKTRACE=1
     volumes:
       - "lndk2:/root/.lndk"
       - "lnd2:/root/.lnd:ro"
+      - "./docker/lndk/wait-for-lnd.sh:/wait-for-lnd.sh"
     networks:
       testing_net:
         ipv4_address: 172.30.2.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
     depends_on:
       - lnd1
-    entrypoint: ["/wait-for-lnd.sh", "lnd1", "1"]
+    entrypoint: ["/wait-for-lnd.sh", "lnd1"]
     command: --address=https://lnd1:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
     environment:
       - RUST_BACKTRACE=1
@@ -89,7 +89,7 @@ services:
     restart: unless-stopped
     depends_on:
       - lnd2
-    entrypoint: ["/wait-for-lnd.sh", "lnd2", "3"]
+    entrypoint: ["/wait-for-lnd.sh", "lnd2"]
     command: --address=https://lnd2:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
     environment:
       - RUST_BACKTRACE=1

--- a/docker/cln/wait-for-bitcoind.sh
+++ b/docker/cln/wait-for-bitcoind.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Usage:
+#   wait-for-bitcoind.sh <cln-args>
+#
+# Arguments:
+#   cln-args  The arguments to be passed to the lightningd command.
+#
+# This script is used to delay the startup of cln nodes until bitcoind is ready.
+# It uses the bitcoin-cli command to check the status of bitcoind.
+# Once bitcoind is ready, it starts the cln nodes with the provided arguments.
+
 # Function to check if bitcoind is ready
 is_bitcoind_ready() {
   bitcoin-cli -rpcconnect=bitcoind -rpcport=43782 -rpcuser=user -rpcpassword=pass -conf=/root/.lightning/bitcoin/bitcoin.conf getblockchaininfo &> /dev/null
@@ -7,10 +17,14 @@ is_bitcoind_ready() {
 }
 
 # Wait for bitcoind to be ready
+# The until loop will keep looping as long as the is_bitcoind_ready function returns a non-zero value (i.e., bitcoind is not ready).
 until is_bitcoind_ready; do
   echo "Waiting for bitcoind to be ready..."
+  # The sleep command is used to pause the script for 5 seconds between each check.
   sleep 5
 done
 
 # Start cln
+# The exec command is used to replace the current shell process with the lightningd command.
+# The "$@" part is used to pass all arguments to the lightningd command.
 exec lightningd "$@"

--- a/docker/lndk/wait-for-lnd.sh
+++ b/docker/lndk/wait-for-lnd.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Usage:
+#   wait-for-lnd.sh <host> <delay> <lndk-args>
+#
+# Arguments:
+#   host       The host of the lnd's gRPC service.
+#   delay      The delay (in seconds) for the startup of lndk nodes after lnd's gRPC port is ready.
+#   lndk-args  The arguments to be passed to the lndk command.
+
+# Function to check if lnd is ready
+is_lnd_ready() {
+  macaroon=$(base64 /root/.lnd/data/chain/bitcoin/regtest/readonly.macaroon | tr -d '\n')
+  response=$(curl --cacert /root/.lnd/tls.cert -Ss -H "Grpc-Metadata-macaroon: $macaroon" "https://$1:8080/v1/state")
+  if [ $? -ne 0 ]; then
+    echo "Error: curl command failed"
+    echo "Response from curl: $response"
+    return 1
+  fi
+  if echo "$response" | grep -q '"state":"SERVER_ACTIVE"'; then
+    return 0
+  else
+    echo "Error: lnd node state is not SERVER_ACTIVE"
+    echo "Response from lnd: $response"
+    return 1
+  fi
+}
+
+# Wait for lnd to be ready
+# The until loop will keep looping as long as the is_lnd_ready function returns a non-zero value (i.e., the port is not open).
+until is_lnd_ready $1; do
+  echo "Waiting for lnd to be ready..."
+  sleep 2
+done
+
+# Delay startup of lndk nodes
+# The sleep command is used to pause the script for a specified number of seconds before starting lndk.
+# The number of seconds is specified by the second parameter to the script.
+echo "Waiting for another $2 seconds before starting lndk..."
+sleep "$2"
+
+# Start lndk
+# The exec command is used to replace the current shell process with the lndk command.
+# The "${@:3}" part is used to pass all arguments starting from the third one to the lndk command.
+exec lndk "${@:3}"

--- a/docker/lndk/wait-for-lnd.sh
+++ b/docker/lndk/wait-for-lnd.sh
@@ -8,7 +8,6 @@
 #   delay      The delay (in seconds) for the startup of lndk nodes after lnd's gRPC port is ready.
 #   lndk-args  The arguments to be passed to the lndk command.
 
-# Function to check if lnd is ready
 is_lnd_ready() {
   macaroon=$(base64 /root/.lnd/data/chain/bitcoin/regtest/readonly.macaroon | tr -d '\n')
   response=$(curl --cacert /root/.lnd/tls.cert -Ss -H "Grpc-Metadata-macaroon: $macaroon" "https://$1:8080/v1/state")
@@ -33,13 +32,7 @@ until is_lnd_ready $1; do
   sleep 2
 done
 
-# Delay startup of lndk nodes
-# The sleep command is used to pause the script for a specified number of seconds before starting lndk.
-# The number of seconds is specified by the second parameter to the script.
-echo "Waiting for another $2 seconds before starting lndk..."
-sleep "$2"
-
 # Start lndk
 # The exec command is used to replace the current shell process with the lndk command.
 # The "${@:3}" part is used to pass all arguments starting from the third one to the lndk command.
-exec lndk "${@:3}"
+exec lndk "${@:2}"


### PR DESCRIPTION
This pull request mainly focuses on enhancing the startup process of the `lnd` nodes in a Docker environment. The changes include the addition of a REST listener in the `lnd` configuration, the implementation of startup delay scripts for the `lndk` nodes that waits for the lnd nodes to become fully ready before starting lndk, and the modification of the `docker-compose.yml` file to incorporate these scripts into the startup process of the nodes.

Configuration changes:

* [`conf/lnd/lnd.conf`](diffhunk://#diff-b6758e9b35d74ff87e486adcb4da8506973b5578302c8ec59feac707a0e767cdR2): Added a REST listener at `0.0.0.0:8080` to the `lnd` configuration.

Startup delay scripts:

* [`docker/lndk/wait-for-lnd.sh`](diffhunk://#diff-575853f22d3d18ffa1c173b0d9ebaad514b4fd843f9223fc0a45084012dc6572R1-R45): Added a script to delay the startup of `lndk` nodes until `lnd`'s gRPC port is ready. The script checks the status of `lnd` using a `curl` command and starts the `lndk` nodes with the provided arguments after a specified delay once `lnd` is ready.

Docker Compose changes:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R31-R38): Modified the `entrypoint` for the services to use the newly added startup delay scripts. Also added the scripts to the `volumes` of the services. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R31-R38) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R92-R99)