### PR TITLE
Fixed lncli command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To use the CLI commands, you need to pass the node name as the first argument to
 Here's an example of how to use the CLI commands:
 
 ```sh
-./bin/lnd.sh lnd1 getinfo
+./bin/lncli lnd1 getinfo
 ```
 
 In this example, `./bin/lncli` is the bin script for the LND nodes, `lnd1` is the name of the node you're issuing the command against, and `getinfo` is the command you're issuing. This command retrieves information about the `lnd1` node.


### PR DESCRIPTION
The LNCLI command in the readme was outdated or incorrect -- it shows as a `lnd.sh` file that is not present, but I switched it to the `lncli` in the `/bin` and it worked for me.