### PR TITLE
Update node versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     depends_on:
       - lnd1
     entrypoint: ["/wait-for-lnd.sh", "lnd1", "5"]
-    command: --address=https://lnd1:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
+    command: --tls-ip=lndk1.localhost,lndk1.local --address=https://lnd1:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
     environment:
       - RUST_BACKTRACE=1
     volumes:
@@ -91,7 +91,7 @@ services:
     depends_on:
       - lnd2
     entrypoint: ["/wait-for-lnd.sh", "lnd2", "5"]
-    command: --address=https://lnd2:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
+    command: --tls-ip=lndk2.localhost --address=https://lnd2:10009 --cert-path=/root/.lnd/tls.cert --macaroon-path=/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --log-level=trace --grpc-host=0.0.0.0
     environment:
       - RUST_BACKTRACE=1
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   lnd1:
-    image: lightninglabs/lnd:v0.18.0-beta.2
+    image: lightninglabs/lnd:v0.18.3-beta.rc1
     restart: unless-stopped
     depends_on:
       - bitcoind
@@ -73,7 +73,7 @@ services:
       - "ldknode1:/root/.ldknode"
 
   lnd2:
-    image: lightninglabs/lnd:v0.18.0-beta.2
+    image: lightninglabs/lnd:v0.18.3-beta.rc1
     restart: unless-stopped
     depends_on:
       - bitcoind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   lnd1:
-    image: lightninglabs/lnd:v0.18.0-beta.1
+    image: lightninglabs/lnd:v0.18.0-beta.2
     restart: unless-stopped
     depends_on:
       - bitcoind
@@ -73,7 +73,7 @@ services:
       - "ldknode1:/root/.ldknode"
 
   lnd2:
-    image: lightninglabs/lnd:v0.18.0-beta.1
+    image: lightninglabs/lnd:v0.18.0-beta.2
     restart: unless-stopped
     depends_on:
       - bitcoind

--- a/docker/lndk/Dockerfile
+++ b/docker/lndk/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.78-bookworm AS builder
 
 # References for lndk
 ARG LNDK_SOURCE=https://github.com/lndk-org/lndk.git
-ARG LNDK_REF=259de8b8ef0916393a47d96076db518cf94651f9
+ARG LNDK_REF=83e1c90dbef2749272c258ac2e2f3d04eb2f32f6
 
 # Add utils
 RUN apt-get update \

--- a/docker/lndk/Dockerfile
+++ b/docker/lndk/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.78-bookworm AS builder
 
 # References for lndk
 ARG LNDK_SOURCE=https://github.com/lndk-org/lndk.git
-ARG LNDK_REF=60e17a0c94177f7d2d160aa08f5cc32a1274b51e
+ARG LNDK_REF=259de8b8ef0916393a47d96076db518cf94651f9
 
 # Add utils
 RUN apt-get update \

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose down --volumes
+docker compose down --volumes

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -385,8 +385,8 @@ waitForGraphSync() {
 }
 
 restartLndkNodes() {
-  docker-compose restart lndk1
-  docker-compose restart lndk2
+  docker compose restart lndk1
+  docker compose restart lndk2
 
   echo "LNDK nodes restarted successfully."
 }


### PR DESCRIPTION
This pull request includes several updates to the `docker-compose.yml` file, a version bump in the `docker/lndk/Dockerfile`, and some script adjustments to align with the latest Docker Compose command syntax. The most important changes are grouped by theme below:

### Docker Compose Updates:

* Updated `lnd` image versions to `v0.18.3-beta.rc1` for `lnd1` and `lnd2` services (`docker-compose.yml`). [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L3-R3) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L76-R76)
* Added `--tls-ip` option to the `command` for `lnd1` and `lnd2` services (`docker-compose.yml`). [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L21-R21) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L94-R94)

### Dockerfile Update:

* Updated `LNDK_REF` to `83e1c90dbef2749272c258ac2e2f3d04eb2f32f6` in `docker/lndk/Dockerfile`.

### Script Adjustments:

* Replaced `docker-compose` with `docker compose` in `scripts/clean.sh`.
* Replaced `docker-compose` with `docker compose` in `scripts/init.sh`.